### PR TITLE
Use UDP instead of TCP

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "vinted-logger"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Evaldas Buinauskas <evaldas.buinauskas@vinted.com>"]
 edition = "2018"
-description = "Vinted logger for Rust applications"
+description = "Vinted fluentd UDP logger for Rust applications"
 readme = "README.md"
 license = "MIT"
 documentation = "https://github.com/vinted/vinted-logger-rs"
@@ -12,22 +12,19 @@ repository = "https://github.com/vinted/vinted-logger-rs"
 
 [dependencies]
 log = "0.4"
-poston = "0.7.1"
 anyhow = "1.0"
 gethostname = "0.2"
-serde = "1"
 serde_json = "1"
-serde_derive = "1"
+
+[dependencies.serde]
+version = "1"
+features = ["derive"]
 
 [dependencies.log4rs]
-version = "1.0.0-alpha-2"
+version = "1.0.0"
 default-features = false
 features = ["config_parsing", "json_encoder", "yaml_format", "console_appender"]
 
 [dependencies.chrono]
 version = "0.4"
 features = ["serde"]
-
-[dependencies.serde_with]
-version = "1.6.0"
-features = ["macros"]


### PR DESCRIPTION
First native implementation to check if it works on the sandbox.

I'll redo this to use tokio to avoid loops and to reduce CPU utilization.

- Kept only JSON encoder, messages are serialized using serde. Encoders work slightly different than I expected them to
- Removed no longer needed crates
- Added environment to log record

cc @ernestas-vinted 