### PR TITLE
Remove tokio, futures dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vinted-logger"
-version = "0.3.0"
+version = "0.3.1"
 authors = [
     "Evaldas Buinauskas <evaldas.buinauskas@vinted.com>",
     "Martynas Jakimcikas <martynas.jakimcikas@vinted.com>",
@@ -15,17 +15,12 @@ repository = "https://github.com/vinted/vinted-logger-rs"
 
 [dependencies]
 bytes = "1"
-futures-channel = "0.3"
-futures-util = { version = "0.3", features = ["sink"] }
 gethostname = "0.2"
 serde_json = "1"
 serde = "1"
-tokio = { version = "1", features = ["full"] }
-tokio-util = { version = "0.6", features = ["codec", "net"] }
 tracing-subscriber = "0.2"
 tracing-core = "0.1"
 tracing-serde = "0.1"
 
 [dev-dependencies]
-tokio = { version = "1", features = ["full"] }
 tracing = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ futures-util = { version = "0.3", features = ["sink"] }
 gethostname = "0.2"
 serde_json = "1"
 serde = "1"
-tokio = { version = "1", features = ["rt"] }
+tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.6", features = ["codec", "net"] }
 tracing-subscriber = "0.2"
 tracing-core = "0.1"

--- a/examples/console.rs
+++ b/examples/console.rs
@@ -1,8 +1,7 @@
 use std::{error::Error, io};
 use tracing::{debug, error, info, span, warn, Level};
 
-#[tokio::main]
-async fn main() {
+fn main() {
     let _ = vinted_logger::try_init("console", vinted_logger::Target::Console);
 
     let number_of_yaks = 3;
@@ -34,6 +33,7 @@ pub fn shave(yak: usize) -> Result<(), Box<dyn Error + 'static>> {
     }
     Ok(())
 }
+
 pub fn shave_all(yaks: usize) -> usize {
     // Constructs a new span named "shaving_yaks" at the TRACE level,
     // and a field whose key is "yaks". This is equivalent to writing:

--- a/examples/console_json.rs
+++ b/examples/console_json.rs
@@ -1,9 +1,8 @@
 use std::{error::Error, io};
 use tracing::{debug, error, info, span, warn, Level};
 
-#[tokio::main]
-async fn main() {
-    let _ = vinted_logger::try_init("kurbernetes", vinted_logger::Target::Kubernetes);
+fn main() {
+    let _ = vinted_logger::try_init("kubernetes", vinted_logger::Target::Kubernetes);
 
     let number_of_yaks = 3;
     // this creates a new event, outside of any spans.
@@ -34,6 +33,7 @@ pub fn shave(yak: usize) -> Result<(), Box<dyn Error + 'static>> {
     }
     Ok(())
 }
+
 pub fn shave_all(yaks: usize) -> usize {
     // Constructs a new span named "shaving_yaks" at the TRACE level,
     // and a field whose key is "yaks". This is equivalent to writing:

--- a/src/vinted_udp_writer.rs
+++ b/src/vinted_udp_writer.rs
@@ -1,35 +1,60 @@
 use bytes::Bytes;
-use futures_channel::mpsc::{self, Receiver};
-use futures_util::{SinkExt, StreamExt};
-use std::{io, net::SocketAddr};
-use tokio::net::{lookup_host, ToSocketAddrs, UdpSocket};
-use tokio::time;
-use tokio_util::codec::BytesCodec;
-use tokio_util::udp::UdpFramed;
+use std::{
+    io,
+    net::UdpSocket,
+    sync::{
+        mpsc::{channel, Sender},
+        Mutex,
+    },
+};
 use tracing_subscriber::fmt::MakeWriter;
 
-const DEFAULT_BUFFER: usize = 512;
-const DEFAULT_TIMEOUT: u32 = 10_000;
-
-#[derive(Debug, Clone)]
-pub struct VintedUdpWriter {
-    sender: mpsc::Sender<Bytes>,
+#[derive(Debug)]
+pub(crate) struct VintedUdpWriter {
+    addr: &'static str,
+    sender: Mutex<Sender<Bytes>>,
 }
 
 impl VintedUdpWriter {
-    /// Returns a new `VintedUdpWriter` with udp configuration
-    pub fn new(address: &'static str) -> Self {
-        let (sender, receiver) = mpsc::channel::<Bytes>(DEFAULT_BUFFER);
+    pub(crate) fn new(addr: &'static str) -> Self {
+        let (sender, receiver) = channel::<Bytes>();
 
-        background_task(address, receiver);
+        let _ = ::std::thread::spawn(move || {
+            match UdpSocket::bind("127.0.0.1:0") {
+                Ok(socket) => loop {
+                    match receiver.recv() {
+                        Ok(bytes) => {
+                            if let Err(e) = socket.send_to(&bytes, addr) {
+                                eprintln!("Log record can't be sent to fluentd: {}", e);
+                            }
+                        }
+                        Err(e) => {
+                            eprintln!("Can't receive new log record: {}", e);
+                            break;
+                        }
+                    }
+                },
+                Err(e) => {
+                    eprintln!("Couldn't bind to UDP socket: {}", e);
+                }
+            };
+        });
 
-        Self { sender }
+        Self {
+            addr,
+            sender: Mutex::new(sender),
+        }
     }
 }
 
 impl io::Write for VintedUdpWriter {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        let _ = self.sender.clone().try_send(Bytes::from(buf.to_owned()));
+        let _ = self
+            .sender
+            .lock()
+            .unwrap()
+            .send(Bytes::from(buf.to_owned()));
+
         Ok(buf.len())
     }
 
@@ -42,56 +67,6 @@ impl MakeWriter for VintedUdpWriter {
     type Writer = Self;
 
     fn make_writer(&self) -> Self::Writer {
-        (*self).clone()
-    }
-}
-
-fn background_task<T>(addr: T, mut receiver: Receiver<Bytes>)
-where
-    T: ToSocketAddrs,
-    T: Send + Sync + 'static,
-{
-    let task = Box::pin(async move {
-        // Reconnection loop
-        loop {
-            // Do a DNS lookup if `addr` is a hostname
-            let addrs = lookup_host(&addr).await.into_iter().flatten();
-
-            // Loop through the IP addresses that the hostname resolved to
-            for addr in addrs {
-                handle_udp_connection(addr, &mut receiver).await;
-            }
-
-            // Sleep before re-attempting
-            time::sleep(time::Duration::from_millis(DEFAULT_TIMEOUT as u64)).await;
-        }
-    });
-
-    tokio::spawn(task);
-}
-
-async fn handle_udp_connection(addr: SocketAddr, receiver: &mut Receiver<Bytes>) {
-    // Bind address version must match address version
-    let bind_addr = if addr.is_ipv4() {
-        "127.0.0.1:0"
-    } else {
-        "[::]:0"
-    };
-    // Try connect
-    let udp_socket = match UdpSocket::bind(bind_addr).await {
-        Ok(ok) => ok,
-        Err(_) => {
-            return;
-        }
-    };
-
-    // Writer
-    let udp_stream = UdpFramed::new(udp_socket, BytesCodec::new());
-    let (mut sink, _) = udp_stream.split();
-    while let Some(bytes) = receiver.next().await {
-        if let Err(_err) = sink.send((bytes, addr)).await {
-            // TODO: Add handler
-            break;
-        };
+        Self::new(self.addr)
     }
 }

--- a/src/vinted_udp_writer.rs
+++ b/src/vinted_udp_writer.rs
@@ -73,7 +73,7 @@ where
 async fn handle_udp_connection(addr: SocketAddr, receiver: &mut Receiver<Bytes>) {
     // Bind address version must match address version
     let bind_addr = if addr.is_ipv4() {
-        "0.0.0.0:0"
+        "127.0.0.1:0"
     } else {
         "[::]:0"
     };


### PR DESCRIPTION
No longer breaks `srouter` and will remove dependencies for other projects. Running locally:
```
❯ ENVIRONMENT=production cargo run
    Blocking waiting for file lock on package cache
    Updating git repository `https://github.com/vinted/vinted-logger-rs`
    Blocking waiting for file lock on package cache
    Blocking waiting for file lock on package cache
   Compiling h2 v0.3.0
   Compiling vinted-logger v0.3.0 (https://github.com/vinted/vinted-logger-rs?branch=fix/features#647bb005)
   Compiling hyper v0.14.5
   Compiling http-api-problem v0.50.1
   Compiling srouter v0.1.0 (/home/ebuinauskas/Git/srouter)
    Finished dev [unoptimized + debuginfo] target(s) in 31.43s
     Running `target/debug/srouter`
Can't receive new log record: receiving on a closed channel
Can't receive new log record: receiving on a closed channel
Can't receive new log record: receiving on a closed channel
Can't receive new log record: receiving on a closed channel
```

cc @ernestas-vinted @Jakimcikas 