### PR TITLE
Change default log level to info

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,20 +24,22 @@ pub fn try_init(
     facility: &'static str,
     target: Target,
 ) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
+    let filter_layer = EnvFilter::try_from_default_env().or_else(|_| EnvFilter::try_new("info"))?;
+
     match target {
         Target::UdpJson => tracing_subscriber::fmt()
-            .with_env_filter(EnvFilter::from_default_env())
+            .with_env_filter(filter_layer)
             .with_writer(vinted_udp_writer::VintedUdpWriter::new("127.0.0.1:9091"))
             .fmt_fields(tracing_subscriber::fmt::format::JsonFields::new())
             .event_format(vinted_json_formatter::VintedJson::new(facility))
             .try_init(),
         Target::ConsoleJson => tracing_subscriber::fmt()
-            .with_env_filter(EnvFilter::from_default_env())
+            .with_env_filter(filter_layer)
             .fmt_fields(tracing_subscriber::fmt::format::JsonFields::new())
             .event_format(vinted_json_formatter::VintedJson::new(facility))
             .try_init(),
         Target::Console => tracing_subscriber::fmt()
-            .with_env_filter(EnvFilter::from_default_env())
+            .with_env_filter(filter_layer)
             .try_init(),
     }
 }


### PR DESCRIPTION
Fixes issue @KazaBen spotted.

```shell
vinted-logger-rs on  master [!] is 📦 v0.3.1 via 🦀 v1.51.0 
❯ cargo run --package vinted-logger --example console
    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
     Running `target/debug/examples/console`
Apr 26 13:18:28.790  INFO console: preparing to shave yaks number_of_yaks=3
Apr 26 13:18:28.790  INFO console: shaving yaks
Apr 26 13:18:28.790  WARN shave{yak=3}: console: could not locate yak!
Apr 26 13:18:28.791 ERROR console: failed to shave yak! yak=3 error=shaving yak failed!
Apr 26 13:18:28.791  INFO console: yak shaving completed. all_yaks_shaved=false

vinted-logger-rs on  fix/default_log_level_info is 📦 v0.3.1 via 🦀 v1.51.0 
❯ RUST_LOG=debug cargo run --package vinted-logger --example console
    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
     Running `target/debug/examples/console`
Apr 26 13:18:30.126  INFO console: preparing to shave yaks number_of_yaks=3
Apr 26 13:18:30.127  INFO console: shaving yaks
Apr 26 13:18:30.127 DEBUG shave{yak=1}: console: hello! I'm gonna shave a yak. excitement="yay!"
Apr 26 13:18:30.127 DEBUG shave{yak=1}: console: yak shaved successfully
Apr 26 13:18:30.127 DEBUG console: yak=1 shaved=true
Apr 26 13:18:30.127 DEBUG console: yaks_shaved=1
Apr 26 13:18:30.127 DEBUG shave{yak=2}: console: hello! I'm gonna shave a yak. excitement="yay!"
Apr 26 13:18:30.127 DEBUG shave{yak=2}: console: yak shaved successfully
Apr 26 13:18:30.127 DEBUG console: yak=2 shaved=true
Apr 26 13:18:30.127 DEBUG console: yaks_shaved=2
Apr 26 13:18:30.127 DEBUG shave{yak=3}: console: hello! I'm gonna shave a yak. excitement="yay!"
Apr 26 13:18:30.127  WARN shave{yak=3}: console: could not locate yak!
Apr 26 13:18:30.128 DEBUG console: yak=3 shaved=false
Apr 26 13:18:30.128 ERROR console: failed to shave yak! yak=3 error=shaving yak failed!
Apr 26 13:18:30.128 DEBUG console: yaks_shaved=2
Apr 26 13:18:30.128  INFO console: yak shaving completed. all_yaks_shaved=false
```